### PR TITLE
Add back missing global

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/webgl/preload.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/preload.js
@@ -24,6 +24,8 @@ var total_model_count = 0;
 var load_count = 0;
 var webgl_materials = {};
 
+var meshes = {};
+
 var model_filenames = ["AEGIS Cruiser",     "Helicopter",    "Pikemen",
                        "Alpine Troops",     "Horsemen",
                        "Archers",           "citywalls",        "Howitzer",      "Riflemen",


### PR DESCRIPTION
A `meshes` global necessary for preloading has been removed in fd8c4941, this adds it back