### PR TITLE
Bug fix: deleting/loading saved files fails.

### DIFF
--- a/freeciv-web/src/main/java/org/freeciv/servlet/DeleteSaveGame.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/DeleteSaveGame.java
@@ -32,9 +32,9 @@ import javax.servlet.*;
 import javax.servlet.http.*;
 import javax.sql.DataSource;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.freeciv.services.Validation;
 import org.freeciv.util.Constants;
-
 
 /**
  * Deletes a savegame.
@@ -73,7 +73,7 @@ public class DeleteSaveGame extends HttpServlet {
 					"Invalid username");
 			return;
 		}
-		if (savegame == null || savegame.length() > 100 || savegame.contains(".") || savegame.contains("/") || savegame.contains("\\")) {
+		if (savegame == null || savegame.length() > 100 || savegame.contains("/") || savegame.contains("\\")) {
 			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
 					"Invalid savegame");
 			return;
@@ -99,11 +99,8 @@ public class DeleteSaveGame extends HttpServlet {
 				return;
 			} else {
 				String hashedPasswordFromDB = rs1.getString(1);
-				if (hashedPasswordFromDB == null || secure_password == null) {
-					response.getOutputStream().print("Failed auth when deleting.");
-					return;
-				}
-				if ( hashedPasswordFromDB.equals(Crypt.crypt(secure_password, hashedPasswordFromDB))) {
+				if (hashedPasswordFromDB != null &&
+						hashedPasswordFromDB.equals(DigestUtils.sha256Hex(secure_password))) {
 					// Login OK!
 				} else {
 					response.getOutputStream().print("Failed");
@@ -125,22 +122,26 @@ public class DeleteSaveGame extends HttpServlet {
 		}
 
 		try {
-			if (savegame.equals("ALL")) {
-				File folder = new File(savegameDirectory + "/" + username);
-				if (!folder.exists()) {
-					response.getOutputStream().print("Error!");
-				} else {
-					for (File savegameFile: folder.listFiles()) {
-						if (savegameFile.exists() && savegameFile.isFile() && savegameFile.getName().endsWith(".sav.xz")) {
-							Files.delete(savegameFile.toPath());
-						}
+			File folder = new File(savegameDirectory + "/" + username);
+			if (!folder.exists()) {
+				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+						"Save folder under the given username cannot be found.");
+				return;
+			} 
+			boolean fileFound = false;
+			for (File savegameFile: folder.listFiles()) {
+				if (savegameFile.exists() && savegameFile.isFile()) {
+					if (savegame.equals("ALL") || savegameFile.getName().startsWith(savegame)){
+						// NOTE: the server does not distinguish saved games of different extensions when loading. So we can delete all of them.
+						Files.delete(savegameFile.toPath());
+						fileFound = true;
 					}
 				}
-			} else {
-				File savegameFile = new File(savegameDirectory + username + "/" + savegame + ".sav.xz");
-				if (savegameFile.exists() && savegameFile.isFile() && savegameFile.getName().endsWith(".sav.xz")) {
-					Files.delete(savegameFile.toPath());
-				}
+			}
+			if (!fileFound) {
+				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+						"Saved game not found.");
+				return;
 			}
 		} catch (Exception err) {
 			response.setHeader("result", "error");

--- a/freeciv-web/src/main/java/org/freeciv/servlet/ListSaveGames.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/ListSaveGames.java
@@ -79,7 +79,13 @@ public class ListSaveGames extends HttpServlet {
 
 					for (File file : files) {
 						if (file.isFile()) {
-							buffer.append(file.getName().replaceAll(".sav.xz", ""));
+							String name = file.getName();
+							if (name.endsWith(".sav.xz")) {
+								name = name.replaceAll(".sav.xz", "");
+							} else if (name.endsWith(".sav.zst")) {
+								name = name.replaceAll(".sav.zst", "");
+							}
+							buffer.append(name);
 							buffer.append(';');
 						}
 					}


### PR DESCRIPTION
Changes:
- Server saves the file in different possible formats, including '.xz' and '.zst'. Currently some logic hardcodes the filename to use the '.xz' extension, which causes failures when the file is saved as '.zst'. This happends when a game is loaded and saved again. See https://gist.github.com/SiyuanQi/f5890efc30c661b5212adc0fb233e8c1 for a screenshot.
- Keep the login logic consistent with LoginUser.java: https://github.com/fciv-net/fciv-net/blob/main/freeciv-web/src/main/java/org/freeciv/servlet/LoginUser.java#L83-L84